### PR TITLE
Correct cron error

### DIFF
--- a/conf/cron
+++ b/conf/cron
@@ -1,8 +1,8 @@
-0,5,10,15,20,25,30,35,40,45,50,55 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:segments:update > /dev/null 2>&1
-3,8,12,17,22,27.32.37,42,47,52,57 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:campaigns:update > /dev/null 2>&1
-1,6,11,16,21,26,31,36,41,46,51,56 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:campaigns:trigger > /dev/null 2>&1
-*/10 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:broadcasts:send > /dev/null 2>&1
-0,15,30,45 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:emails:send > /dev/null 2>&1
-15 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:webhooks:process > /dev/null 2>&1
-0 0 1 * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:maintenance:cleanup –-days-old=90 –no-interaction > /dev/null 2>&1
-0 4 * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/console mautic:iplookup:download > /dev/null 2>&1
+0,5,10,15,20,25,30,35,40,45,50,55 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:segments:update > /dev/null 2>&1
+3,8,12,17,22,27.32.37,42,47,52,57 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:campaigns:update > /dev/null 2>&1
+1,6,11,16,21,26,31,36,41,46,51,56 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:campaigns:trigger > /dev/null 2>&1
+*/10 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:broadcasts:send > /dev/null 2>&1
+0,15,30,45 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:emails:send > /dev/null 2>&1
+15 * * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:webhooks:process > /dev/null 2>&1
+0 0 1 * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:maintenance:cleanup –-days-old=90 –no-interaction > /dev/null 2>&1
+0 4 * * * __APP__ /usr/bin/php__PHPVERSION__ __INSTALL_DIR__/bin/console mautic:iplookup:download > /dev/null 2>&1


### PR DESCRIPTION
## Problem

- Correct cron bug "Could not open input file: /var/www/mautic/console"

## Solution

- change path and add /bin/ before

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
